### PR TITLE
ch.qos.logback:logback-core:1.1.10 was duplicated

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,13 +82,6 @@
       <version>1.7.0</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-core</artifactId>
-      <version>1.1.10</version>
-
-    </dependency>
-
   </dependencies>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,7 @@
           <plugin>
             <groupId>io.fabric8</groupId>
             <artifactId>fabric8-maven-plugin</artifactId>
+            <version>3.5.22</version>
             <executions>
               <execution>
                 <id>fmp</id>

--- a/src/main/java/io/openshift/booster/HttpApplication.java
+++ b/src/main/java/io/openshift/booster/HttpApplication.java
@@ -16,7 +16,7 @@ import static io.vertx.core.http.HttpHeaders.CONTENT_TYPE;
 
 public class HttpApplication extends AbstractVerticle {
 
-  protected static final String template = "Aloha, %s!";
+  protected static final String template = "Aloha !!, %s!";
 
   @Override
   public void start(Future<Void> future) {


### PR DESCRIPTION
It causes the following message: 

Some problems were encountered while building the effective model for red.burr:vertx-eventbus:jar:1.0.0-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: ch.qos.logback:logback-core:jar -> duplicate declaration of version
 1.1.10 @ line 85, column 17